### PR TITLE
Updated ios setup instructions and added troubleshooting section for issues faced on Mac OS.

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -90,9 +90,13 @@ machine api.mapbox.com
 ```
 
 ### Install dependencies
-Run a `pod install` to install required dependencies.
+- Navigate to the `ios` directory for your project with `cd ios`
+- Run `pod install` in the `ios` directory.
 
-**IMPORTANT: If you are using a new MAC with the M1 or M2 chip, you may run into this issue:**
+### Troubleshooting iOS issues
+
+
+If you are using a machine with MacOS 14 or newer (typically with the M1 or M2 chip), you may run into this issue:
 
 ```bash
 [!] CocoaPods could not find compatible versions for pod "MapboxMaps":
@@ -107,19 +111,29 @@ You have either:
  * mistyped the name or version.
  * not added the source repo that hosts the Podspec to your Podfile.
 ```
-If this happens, run:
+If this happens, follow the instructions and run `pod repo update` or `pod install --repo-update`.
+
+If this issue still occurs, you may need to update your command-line tools. This can be done using the following commands:
 
 ```bash
-sudo arch -x86_64 gem install ffi
+sudo rm -rf /Library/Developer/CommandLineTools
 ```
-After this is complete, run:
+
 ```bash
-arch -x86_64 pod repo update
+xcode-select --install
 ```
-Followed by:
+**You may need to restart your machine after running the above.**
+
+If the above does not fix it, you may need to update homebrew using the following steps:
+
 ```bash
-arch -x86_64 pod install
+brew update
 ```
+
+```bash
+brew upgrade
+```
+**You may need to restart your machine after running the above.**
 
 </TabItem>
 <TabItem value="android">

--- a/docs/install.md
+++ b/docs/install.md
@@ -89,6 +89,38 @@ machine api.mapbox.com
   password sk.ey...
 ```
 
+### Install dependencies
+Run a `pod install` to install required dependencies.
+
+**IMPORTANT: If you are using a new MAC with the M1 or M2 chip, you may run into this issue:**
+
+```bash
+[!] CocoaPods could not find compatible versions for pod "MapboxMaps":
+  In Podfile:
+    rnmapbox-maps (from `../node_modules/@rnmapbox/maps`) was resolved to 10.1.8, which depends on
+      MapboxMaps (~> 10.16.4)
+
+None of your spec sources contain a spec satisfying the dependency: `MapboxMaps (~> 10.16.4)`.
+
+You have either:
+ * out-of-date source repos which you can update with `pod repo update` or with `pod install --repo-update`.
+ * mistyped the name or version.
+ * not added the source repo that hosts the Podspec to your Podfile.
+```
+If this happens, run:
+
+```bash
+sudo arch -x86_64 gem install ffi
+```
+After this is complete, run:
+```bash
+arch -x86_64 pod repo update
+```
+Followed by:
+```bash
+arch -x86_64 pod install
+```
+
 </TabItem>
 <TabItem value="android">
 


### PR DESCRIPTION
This PR updates the ios setup instructions with steps that may be required for users on Mac OS with the M1 or M2 chip. It also includes a section with information for troubleshooting some issues that may be faced on Mac OS 14 or greater.