### PR TITLE
Update installation docs for version 10.2.*

### DIFF
--- a/docs/install.md
+++ b/docs/install.md
@@ -6,16 +6,16 @@ title: Install
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 
-> Note that those instructions applies to the 10.1 version. Please visit the installation guide for the older 10.0.15 which can be found on the [github v10.0 branch of the project](https://github.com/rnmapbox/maps/tree/v10.0#prerequisite
-)
+> Note that those instructions applies to the 10.2.* versions of @rnmapbox/maps.
 # Configure credentials
 
-Before installing @rnmapbox/maps you'll need to get the proper credentials.
-You'll need two tokens:
-  - Secret access token with (Downloads:Read) scope to download iOS and Android SDK from mapbox. The secret token starts with `sk.ey`
-  - Public token to use as accessToken when running the app. The public token starts with `pk.ey`
+Before installing @rnmapbox/maps you'll need to get your Mapbox access token.
 
-See [Configure Credential](https://docs.mapbox.com/ios/navigation/guides/get-started/install/#configure-credentials) on mapbox.com for details.
+To grab your token, open up a browser and go to your account's tokens page: https://console.mapbox.com/account/access-tokens/
+
+On the top of your token list, copy your **Default Public Token**.
+
+For more details, see [Configure Credentials](https://docs.mapbox.com/ios/maps/guides/install/#part-1-create-and-configure-your-credentials) on mapbox.com.
 
 # Install
 
@@ -75,20 +75,6 @@ post_install do |installer|
 end
 ```
 
-### Verify .netrc
-Make sure your `.netrc` is configured with your secret access token, as described by the [mapbox docs](https://docs.mapbox.com/ios/maps/guides/install/#configure-credentials). To verify execute:
-
-```bash
-grep -A 4 api.mapbox.com ~/.netrc
-```
-
-This should output something like:
-```bash
-machine api.mapbox.com
-  login mapbox
-  password sk.ey...
-```
-
 </TabItem>
 <TabItem value="android">
 
@@ -104,33 +90,10 @@ allprojects {
     repositories {
         maven {
             url 'https://api.mapbox.com/downloads/v2/releases/maven'
-            authentication {
-                basic(BasicAuthentication)
-            }
-            credentials {
-                // Do not change the username below.
-                // This should always be `mapbox` (not your username).
-                username = 'mapbox'
-                // Use the secret token you stored in gradle.properties as the password
-                password = project.properties['MAPBOX_DOWNLOADS_TOKEN'] ?: ""
-            }
         }
     }
 }
 // highlight-end
-```
-
-### Verify MAPBOX_DOWNLOADS_TOKEN in gradle.properties
-
-Make sure your global `gradle.properties` is configured with your secret access token, as described by the [mapbox docs](https://docs.mapbox.com/android/maps/guides/install/#configure-credentials). To verify execute:
-
-```bash
-grep -R MAPBOX_DOWNLOADS_TOKEN ~/.gradle/gradle.properties
-```
-
-This should output something like:
-```bash
-/Users/foo/.gradle/gradle.properties:MAPBOX_DOWNLOADS_TOKEN=sk.ey...
 ```
 
 </TabItem>
@@ -138,27 +101,15 @@ This should output something like:
 
 ### Plugin configuration
 
-Set `RNMapboxMapsDownloadToken` to your secret token. See the [credentials instructions](https://docs.mapbox.com/ios/maps/guides/install/#configure-credentials) on mapbox.com.
-
-Add `RNMapboxMapsDownloadToken` to the @rnmapbox/maps [config plugin](https://docs.expo.io/guides/config-plugins/) in the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.{json,config.js,config.ts}`:
-
-
-:::warning
-RNMapboxMapsDownloadToken is only intended for eas, and [it can cause your RNMapboxMapsDownloadToken to leak](RNMapboxMapsDownloadTokenDetails). 
-:::
+Add the @rnmapbox/maps [config plugin](https://docs.expo.io/guides/config-plugins/) to the [`plugins`](https://docs.expo.io/versions/latest/config/app/#plugins) array of your `app.{json,config.js,config.ts}`:
 
 ```json
 {
   "expo": {
     "plugins": [
-      [
 // highlight-start
-        "@rnmapbox/maps",
-        {
-          "RNMapboxMapsDownloadToken": "sk.ey.."
-        }
+      "@rnmapbox/maps"
 // highlight-end
-      ]
     ]
   }
 }

--- a/docs/install.md
+++ b/docs/install.md
@@ -13,7 +13,7 @@ Before installing @rnmapbox/maps you'll need to get your Mapbox access token.
 
 To grab your token, open up a browser and go to your account's tokens page: https://console.mapbox.com/account/access-tokens/
 
-On the top of your token list, copy your **Default Public Token**.
+On the top of your token list, copy your **Default Public Token**. The public token starts with `pk.ey`.
 
 For more details, see [Configure Credentials](https://docs.mapbox.com/ios/maps/guides/install/#part-1-create-and-configure-your-credentials) on mapbox.com.
 


### PR DESCRIPTION
- Update version reference from 10.1 to 10.2.*
- Remove download token requirements (no longer needed)
- Simplify credentials section to only require public access token
- Update iOS configuration to remove .netrc setup
- Update Android configuration to remove authentication/credentials from maven repo
- Update Expo configuration to remove RNMapboxMapsDownloadToken
- Add direct link to Mapbox access tokens page
- Update credentials documentation link